### PR TITLE
Minor improvements for Celery Beat healthcheck

### DIFF
--- a/tg_utils/health_check/checks/celery_beat/backends.py
+++ b/tg_utils/health_check/checks/celery_beat/backends.py
@@ -17,5 +17,7 @@ class CeleryBeatHealthCheck(BaseHealthCheckBackend, HealthCheckSettingsMixin):
         last_beat_time = cache.get(CACHE_KEY, None)
         if last_beat_time is None:
             self.add_error(ServiceUnavailable("Celery beat is not scheduling tasks"))
-        elif (datetime.now() - last_beat_time).seconds > TIMEOUT + DELAY_THRESHOLD:
-            self.add_error(ServiceUnavailable("Celery beat tasks are delayed"))
+        elif (datetime.now() - last_beat_time).seconds > DELAY_THRESHOLD:
+            self.add_error(ServiceUnavailable("Celery beat tasks are delayed, last ran at {last_beat_time}.".format(
+                last_beat_time=last_beat_time,
+            )))

--- a/tg_utils/health_check/checks/celery_beat/tasks.py
+++ b/tg_utils/health_check/checks/celery_beat/tasks.py
@@ -2,10 +2,10 @@ from django.core.cache import cache
 from django.utils.datetime_safe import datetime
 
 from celery import shared_task
-from tg_utils.health_check.checks.celery_beat.backends import (CACHE_KEY,
-                                                               TIMEOUT)
+from tg_utils.health_check.checks.celery_beat.backends import CACHE_KEY
 
 
 @shared_task(ignore_result=False)
 def timestamp_task():
-    cache.set(CACHE_KEY, datetime.now(), timeout=TIMEOUT*2)
+    # timeout=None causes value to be stored forever
+    cache.set(CACHE_KEY, datetime.now(), timeout=None)


### PR DESCRIPTION
* cache last task execution time forever, for more comprehensive error message
* allow to control task execution frequency and error threshold in independent way