### PR TITLE
ReadOnlyAdminMixin mixin and annotate decorator

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.7.4 (2019-12-11)
+------------------
+
+* Add `ReadOnlyAdminMixin` for Django admin views
+* Add a decorator for annotating admin methods (`annotate_admin_method`)
+
+
 0.7.3 (2019-09-10)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,8 @@ Features
 * Using hashids for models (instead of exposing primary keys).
 * System checks for email and Sentry configuration.
 * Mixin for easier implementation of ordering in Django's generic ListView.
+* Mixin for making admin view read-only.
+* Decorator for annotating admin methods.
 * JS/CSS compressors for `Django Compressor <https://django-compressor.readthedocs.org/en/latest/>`_.
 * Health-check endpoints (with and without token authentication)
 

--- a/tests/test_importing.py
+++ b/tests/test_importing.py
@@ -19,3 +19,4 @@ def test_imports():
     from tg_utils import profiling
     from tg_utils import signals
     from tg_utils import uuid
+    from tg_utils import decorators

--- a/tg_utils/__init__.py
+++ b/tg_utils/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'Thorgate'
 __email__ = 'code@thorgate.eu'
-__version__ = '0.7.3'
+__version__ = '0.7.4'

--- a/tg_utils/decorators.py
+++ b/tg_utils/decorators.py
@@ -1,0 +1,32 @@
+def annotate_admin_method(**kwargs):
+    """
+    A decorator for method-based fields and actions of ModelAdmin classes.
+
+    Usage:
+
+    ::
+
+        class CustomAdmin(admin.ModelAdmin):
+            def do_something(self, obj):
+                # ...
+
+            do_something.short_description = _('Do Something')
+            do_something.admin_order_field = 'name'
+
+    Can be replaced with:
+
+    ::
+
+        class CustomAdmin(admin.ModelAdmin):
+
+        @annotate_admin_method(short_description=_('Do Something'), admin_order_field='name')
+        def do_something(self, obj):
+            # ...
+    """
+
+    def wrapped(f):
+        for attr_name, attr_value in kwargs.items():
+            setattr(f, attr_name, attr_value)
+        return f
+
+    return wrapped

--- a/tg_utils/mixins.py
+++ b/tg_utils/mixins.py
@@ -56,3 +56,34 @@ class OrderingOptionsMixin:
                 return query_params.urlencode()
 
         return super()[item]
+
+
+class ReadOnlyAdminMixin:
+    """
+    Mixin that makes an admin view read-only to protect a model from changes.
+    Makes all fields read-only, removes save buttons, delete, and add permissions.
+    """
+
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        """ customize add/edit form to remove save / save and continue """
+        extra_context = extra_context or {}
+        extra_context['show_save_and_continue'] = False
+        extra_context['show_save'] = False
+        return super().change_view(request, object_id, extra_context=extra_context)
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        if 'delete_selected' in actions:
+            del actions['delete_selected']
+        return actions
+
+    def get_readonly_fields(self, request, obj=None):
+        fields = [field.name for field in obj._meta.fields]
+        many_to_many = [field.name for field in obj._meta.many_to_many]
+        return list(self.readonly_fields) + fields + many_to_many
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False


### PR DESCRIPTION
Add a mixin that makes an admin view read-only to protect a model from changes.
Add a decorator for annotating method-based fields and actions of ModelAdmin classes.