### PR TITLE
Fix health-check app initialization issue

### DIFF
--- a/tg_utils/health_check/checks/celery_beat/apps.py
+++ b/tg_utils/health_check/checks/celery_beat/apps.py
@@ -23,7 +23,8 @@ class HealthCheckConfig(AppConfig):
             )
 
         # Set initial timestamp not to fail the health-check before it runs for the first time
-        timestamp_task.apply_async()
+        # Don't use apply_async - otherwise, the whole initialisation will fail if celery fails
+        timestamp_task()
 
         module_name, class_name = cls.rsplit(".", 1)
         app_module = importlib.import_module(module_name)


### PR DESCRIPTION
If there is no redis connectivity on app initialization or other severe
error occurred that would prevent celery task from running, health-
check would bring the whole app down instead of just failing.